### PR TITLE
Fix: Config not saving on restart

### DIFF
--- a/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
@@ -130,8 +130,8 @@ object ravenAddonsConfig : Vigilant(
 
     @Property(
         type = PropertyType.TEXT,
-        name = "Better Device Notifications Title.",
-        description = "Choose a title.",
+        name = "Title",
+        description = "Choose a title for Better Device Notifications.",
         category = "Dungeons",
         subcategory = "Floor 7"
     )
@@ -139,8 +139,8 @@ object ravenAddonsConfig : Vigilant(
 
     @Property(
         type = PropertyType.TEXT,
-        name = "Better Device Notifications SubTitle.",
-        description = "Choose a subtitle.",
+        name = "Subtitle",
+        description = "Choose a subtitle for Better Device Notifications.",
         category = "Dungeons",
         subcategory = "Floor 7"
     )


### PR DESCRIPTION
For some reason, vigilance freaks out with full stops in names so they were removed. Pre-existing users have to delete their original config though as far as I am aware. 