### PR TITLE
Improvement: Split frozen and unfrozen announcer in the config.

### DIFF
--- a/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
@@ -85,6 +85,16 @@ object ravenAddonsConfig : Vigilant(
     var fireFreezeTimer = false
 
     @Property(
+        type = PropertyType.SELECTOR,
+        name = "Fire Freeze Announcer",
+        description = "Announce to your party when a mob becomes frozen or unfrozen.",
+        category = "SkyBlock",
+        subcategory = "Fire Freeze Staff",
+        options = ["None", "Frozen", "Unfrozen", "Both"]
+    )
+    var fireFreezeAnnounce = 0
+
+    @Property(
         type = PropertyType.SWITCH,
         name = "Fire Freeze Notification",
         description = "Sends a title and chat message for when fire freeze is available after a successful fire freeze on a mob.",
@@ -92,15 +102,6 @@ object ravenAddonsConfig : Vigilant(
         subcategory = "Fire Freeze Staff"
     )
     var fireFreezeNotification = false
-
-    @Property(
-        type = PropertyType.SWITCH,
-        name = "Fire Freeze Announcer",
-        description = "Announce to your party when a mob becomes frozen or unfrozen.",
-        category = "SkyBlock",
-        subcategory = "Fire Freeze Staff"
-    )
-    var fireFreezeAnnounce = false
 
     @Property(
         type = PropertyType.SWITCH,

--- a/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
@@ -253,6 +253,8 @@ object ravenAddonsConfig : Vigilant(
 
         this::dropAlertUserName requires this::dropAlert
 
+        this::fireFreezeAnnounce requires this::fireFreezeTimer
+
         this::betterDeviceNotificationTitle requires this::betterDeviceNotification
         this::betterDeviceNotificationSubTitle requires this::betterDeviceNotification
 

--- a/src/main/kotlin/at/raven/ravenAddons/features/skyblock/FireFreezeTimer.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/features/skyblock/FireFreezeTimer.kt
@@ -68,7 +68,7 @@ object FireFreezeTimer {
             ravenAddons.launchCoroutine {
                 delay(5000)
 
-                TitleManager.setTitle("§b§lFREEZE!", "", 2.seconds, 1.seconds, 1.seconds)
+                TitleManager.setTitle("§b§lFREEZE!", "", 3.seconds, 1.seconds, 1.seconds)
                 ChatUtils.chat("Fire Freeze Staff is ready for re-use.")
             }
         }

--- a/src/main/kotlin/at/raven/ravenAddons/features/skyblock/FireFreezeTimer.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/features/skyblock/FireFreezeTimer.kt
@@ -1,6 +1,7 @@
 package at.raven.ravenAddons.features.skyblock
 
 import at.raven.ravenAddons.config.ravenAddonsConfig
+import at.raven.ravenAddons.config.ravenAddonsConfig.fireFreezeAnnounce
 import at.raven.ravenAddons.data.HypixelGame
 import at.raven.ravenAddons.data.HypixelGame.Companion.isNotPlaying
 import at.raven.ravenAddons.event.CommandRegistrationEvent
@@ -67,12 +68,12 @@ object FireFreezeTimer {
             ravenAddons.launchCoroutine {
                 delay(5000)
 
-                TitleManager.setTitle("", "§bFIRE FREEZE!", 2.seconds, 1.seconds, 1.seconds)
-                ChatUtils.chat("Fire Freeze Staff is ready for use.")
+                TitleManager.setTitle("§b§lFREEZE!", "", 2.seconds, 1.seconds, 1.seconds)
+                ChatUtils.chat("Fire Freeze Staff is ready for re-use.")
             }
         }
 
-        if (ravenAddonsConfig.fireFreezeAnnounce) {
+        if (fireFreezeAnnounce == 1 || fireFreezeAnnounce == 3) {
             ChatUtils.debug("fireFreezeAnnounce: sending message in 250ms")
             if (freezeMessageCooldown.isInPast()) {
                 freezeMessageCooldown = SimpleTimeMark.now() + 5.seconds
@@ -99,8 +100,9 @@ object FireFreezeTimer {
         for ((entity, timer) in entities) {
             if (timer.isInPast() || !entity.isInWorld()) {
                 frozenEntities.remove(entity)
-                ChatUtils.debug("fireFreezeAnnounce: frozen entity died or is now unfrozen!")
-                if (ravenAddonsConfig.fireFreezeAnnounce && unfreezeMessageCooldown.isInPast() && entity.isInWorld()) {
+                ChatUtils.debug("fireFreezeAnnounce: frozen entity died or is now unfrozen...")
+                if (fireFreezeAnnounce == 2 || fireFreezeAnnounce == 3 && unfreezeMessageCooldown.isInPast() && entity.isInWorld()) {
+                    ChatUtils.debug("fireFreezeAnnounce: sending message for unfrozen...")
                     ChatUtils.sendMessage("/pc [RA] Mob(s) unfroze!")
                     unfreezeMessageCooldown = SimpleTimeMark.now() + 5.seconds
                 }


### PR DESCRIPTION
Users will have more customizability in terms of what messages relating to the Fire Freeze Staff should be announced.
Users must enable the Fire Freeze Timer for them to use the announcer as well.
Changed the title to be more clean for the re freeze.