### PR TITLE
Feature: Required Pants Type

### DIFF
--- a/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
@@ -50,6 +50,24 @@ object ravenAddonsConfig : Vigilant(
 
     @Property(
         type = PropertyType.SWITCH,
+        name = "Required Pants Type",
+        description = "Adds the oolour of pants required to tier 3 a mystic item to it's description.",
+        category = "Pit",
+        subcategory = "Mystics"
+    )
+    var requiredPantsType = false
+
+    @Property(
+        type = PropertyType.SWITCH,
+        name = "Required Pants Type Highlighter",
+        description = "Highlights tier 2 mystics in the Mystic Well based on the colour of pants they require to tier 3.",
+        category = "Pit",
+        subcategory = "Mystics"
+    )
+    var highlightRequiredPantsType = false
+
+    @Property(
+        type = PropertyType.SWITCH,
         name = "DROP Alerts",
         description = "Message a user about your RARE DROPS.",
         category = "SkyBlock",
@@ -471,6 +489,7 @@ object ravenAddonsConfig : Vigilant(
         initialize()
 
         this::carePackageHighlighterColour requires this::carePackageHighlighter
+        this::highlightRequiredPantsType requires this::requiredPantsType
 
         this::dropAlertUserName requires this::dropAlert
 

--- a/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
@@ -51,7 +51,7 @@ object ravenAddonsConfig : Vigilant(
     @Property(
         type = PropertyType.SWITCH,
         name = "Required Pants Type",
-        description = "Adds the oolour of pants required to tier 3 a mystic item to it's description.",
+        description = "Adds the colour of pants required to tier 3 a mystic item to it's description.",
         category = "Pit",
         subcategory = "Mystics"
     )
@@ -60,7 +60,7 @@ object ravenAddonsConfig : Vigilant(
     @Property(
         type = PropertyType.SWITCH,
         name = "Required Pants Type Highlighter",
-        description = "Highlights tier 2 mystics in the Mystic Well based on the colour of pants they require to tier 3.",
+        description = "Highlights mystics in the Mystic Well based on the colour of pants they require to tier 3.",
         category = "Pit",
         subcategory = "Mystics"
     )

--- a/src/main/kotlin/at/raven/ravenAddons/event/TooltipEvent.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/event/TooltipEvent.kt
@@ -1,0 +1,14 @@
+package at.raven.ravenAddons.event
+
+import at.raven.ravenAddons.event.base.RavenEvent
+import net.minecraft.item.ItemStack
+
+class TooltipEvent(val itemStack: ItemStack, private val toolTip0: MutableList<String>) : RavenEvent() {
+
+    var toolTip: MutableList<String>
+        set(value) {
+            toolTip0.clear()
+            toolTip0.addAll(value)
+        }
+        get() = toolTip0
+}

--- a/src/main/kotlin/at/raven/ravenAddons/event/managers/TooltipManager.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/event/managers/TooltipManager.kt
@@ -1,0 +1,14 @@
+package at.raven.ravenAddons.event.managers
+
+import at.raven.ravenAddons.event.TooltipEvent
+import at.raven.ravenAddons.loadmodule.LoadModule
+import net.minecraftforge.event.entity.player.ItemTooltipEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@LoadModule
+object TooltipManager {
+    @SubscribeEvent
+    fun onTooltip(event: ItemTooltipEvent) {
+        TooltipEvent(event.itemStack, event.toolTip).post()
+    }
+}

--- a/src/main/kotlin/at/raven/ravenAddons/features/pit/RequiredPantsType.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/features/pit/RequiredPantsType.kt
@@ -1,0 +1,82 @@
+package at.raven.ravenAddons.features.pit
+
+import at.raven.ravenAddons.config.ravenAddonsConfig
+import at.raven.ravenAddons.data.HypixelGame
+import at.raven.ravenAddons.event.TooltipEvent
+import at.raven.ravenAddons.event.render.container.ContainerBackgroundDrawEvent
+import at.raven.ravenAddons.loadmodule.LoadModule
+import at.raven.ravenAddons.utils.InventoryUtils.getAllItems
+import at.raven.ravenAddons.utils.InventoryUtils.getContainerName
+import at.raven.ravenAddons.utils.RegexUtils.matchMatcher
+import at.raven.ravenAddons.utils.StringUtils.removeColors
+import at.raven.ravenAddons.utils.render.GuiRenderUtils.highlight
+import gg.essential.universal.ChatColor
+import net.minecraft.client.gui.inventory.GuiChest
+import net.minecraft.inventory.ContainerChest
+import net.minecraft.item.ItemStack
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@LoadModule
+object RequiredPantsType {
+    private val colors = listOf(
+        "Red" to ChatColor.RED,
+        "Yellow" to ChatColor.YELLOW,
+        "Blue" to ChatColor.BLUE,
+        "Orange" to ChatColor.GOLD,
+        "Green" to ChatColor.GREEN,
+    )
+
+    private val mysticPattern = "Tier (?<tier>I+) .+".toPattern()
+
+    @SubscribeEvent
+    fun onItemHover(event: TooltipEvent) {
+        if (!isEnabled()) return
+
+        val stack = event.itemStack
+        val name = stack.displayName.removeColors()
+
+        mysticPattern.matchMatcher(name) {
+            val tier = group("tier")
+            if (tier == "III") return
+
+            val nonce = stack.getNonce() ?: return
+            if (nonce <= 20) return
+
+            val (colorName, colorCode) = colors[nonce % colors.size]
+
+            event.toolTip += listOf("", "§7Requires $colorCode$colorName Pants §7to Tier 3")
+        }
+    }
+
+    @SubscribeEvent
+    fun onContainerBackground(event: ContainerBackgroundDrawEvent) {
+        if (!isEnabled() || !ravenAddonsConfig.highlightRequiredPantsType) return
+        val gui = event.gui
+        if (gui !is GuiChest || gui.getContainerName() != "Mystic Well") return
+
+        val inventory = gui.inventorySlots as ContainerChest
+
+        for ((slot, stack) in inventory.getAllItems()) {
+            val name = stack?.displayName?.removeColors() ?: continue
+
+            mysticPattern.matchMatcher(name) {
+                val tier = group("tier")
+                if (tier == "III") return@matchMatcher
+
+                val nonce = stack.getNonce() ?: return@matchMatcher
+                if (nonce <= 20) return@matchMatcher
+
+                val color = colors[nonce % 5].second.color ?: return@matchMatcher
+                slot.highlight(color)
+            }
+        }
+    }
+
+    private fun ItemStack.getNonce(): Int? {
+        val tag = tagCompound ?: return null
+        val extraAttributes = tag.getCompoundTag("ExtraAttributes") ?: return null
+        return extraAttributes.getInteger("Nonce")
+    }
+
+    private fun isEnabled() = HypixelGame.inPit && ravenAddonsConfig.requiredPantsType
+}


### PR DESCRIPTION
## What
Adds a part in the description of an item that displays the required pants type to tier 3 it. Also adds an option to highlight mystics in the mystic well based on their required pants type.

<details>
<summary>Images</summary>

<!-- drop images here -->
![grafik](https://github.com/user-attachments/assets/1c45ec7e-abc6-4875-91dc-76c9d66fcbda)
![grafik](https://github.com/user-attachments/assets/b2805a81-022a-4195-b335-6fcc8b0563af)

</details>