### PR TITLE
Feature: Add Kuudra Chest Limit Warning

### DIFF
--- a/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/config/ravenAddonsConfig.kt
@@ -493,6 +493,25 @@ object ravenAddonsConfig : Vigilant(
 
     @Property(
         type = PropertyType.SWITCH,
+        name = "Kuudra Chest Limit Warning",
+        description = "Warns the user upon completing 60 Kuudra runs without claiming their chests.",
+        category = "Kuudra",
+        subcategory = "Chest Limit"
+    )
+    var kuudraChestLimitWarning = false
+
+    @Property(
+        type = PropertyType.NUMBER,
+        name = "Kuudra Chest Limit Warning Number",
+        description = "Stores the amount of Kuudra completions for Kuudra Chest Limit Warning.",
+        category = "Kuudra",
+        subcategory = "Chest Limit",
+        hidden = true,
+    )
+    var kuudraChestLimitWarningNumber = 0
+
+    @Property(
+        type = PropertyType.SWITCH,
         name = "!since",
         description = "Announces to the party how many mobs you have spawned before spawning an Inquisitor.",
         category = "Party Commands",

--- a/src/main/kotlin/at/raven/ravenAddons/features/kuudra/KuudraChestLimit.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/features/kuudra/KuudraChestLimit.kt
@@ -36,7 +36,7 @@ object KuudraChestLimit {
         ravenAddonsConfig.kuudraChestLimitWarningNumber += 1
         ravenAddonsConfig.markDirty()
 
-        if (ravenAddonsConfig.kuudraChestLimitWarningNumber <= 60) {
+        if (ravenAddonsConfig.kuudraChestLimitWarningNumber >= 60) {
             ChatUtils.chat("You've done 60 Kuudra runs without checking your chests.")
             TitleManager.setTitle("§cOpen Chests", "", 3.seconds, 1.seconds, 1.seconds)
         }

--- a/src/main/kotlin/at/raven/ravenAddons/features/kuudra/KuudraChestLimit.kt
+++ b/src/main/kotlin/at/raven/ravenAddons/features/kuudra/KuudraChestLimit.kt
@@ -1,0 +1,49 @@
+package at.raven.ravenAddons.features.kuudra
+
+import at.raven.ravenAddons.config.ravenAddonsConfig
+import at.raven.ravenAddons.data.SkyBlockIsland
+import at.raven.ravenAddons.event.chat.ChatReceivedEvent
+import at.raven.ravenAddons.loadmodule.LoadModule
+import at.raven.ravenAddons.ravenAddons
+import at.raven.ravenAddons.utils.ChatUtils
+import at.raven.ravenAddons.utils.RegexUtils.matchMatcher
+import at.raven.ravenAddons.utils.TitleManager
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.seconds
+
+@LoadModule
+object KuudraChestLimit {
+    private val kuudraCompletePattern = "^\\s+KUUDRA DOWN!$".toPattern()
+
+    private val chestOpenedPattern = "^PAID CHEST REWARDS$".toPattern()
+
+    @SubscribeEvent
+    fun onChat(event: ChatReceivedEvent) {
+        if (!ravenAddonsConfig.kuudraChestLimitWarning) return
+
+        kuudraCompletePattern.matchMatcher(event.cleanMessage) {
+            if (!SkyBlockIsland.KUUDRA.isInIsland()) return
+            add()
+        }
+
+        chestOpenedPattern.matchMatcher(event.cleanMessage) {
+            if (SkyBlockIsland.KUUDRA.isInIsland()) return
+            KuudraChestLimit.reset()
+        }
+    }
+
+    private fun add() {
+        ravenAddonsConfig.kuudraChestLimitWarningNumber += 1
+        ravenAddonsConfig.markDirty()
+
+        if (ravenAddonsConfig.kuudraChestLimitWarningNumber <= 60) {
+            ChatUtils.chat("You've done 60 Kuudra runs without checking your chests.")
+            TitleManager.setTitle("§cOpen Chests", "", 3.seconds, 1.seconds, 1.seconds)
+        }
+    }
+
+    private fun reset() {
+        ravenAddonsConfig.kuudraChestLimitWarningNumber += 1
+        ravenAddonsConfig.markDirty()
+    }
+}


### PR DESCRIPTION
Warns the user when they have not opened a paid chest outside of the Kuudra in 60 runs. 